### PR TITLE
docs: remove nextra from title

### DIFF
--- a/docs/src/pages/docs/api.mdx
+++ b/docs/src/pages/docs/api.mdx
@@ -16,7 +16,7 @@ optional.
 
 * `type`<br/>
 The type field of the validation object describes how and when the form fields should be validated. The 3 options
-are: '`change`, `blur`, and `submit`. It defaults to `change`.
+are: `change`, `blur`, and `submit`. It defaults to `change`.
 
 * `schema`<br/>
 The `schema` is required if the validation parameter is provided. These are the rules provided to the hook that
@@ -91,7 +91,7 @@ const form = useForm<FormValues>({
 ```
 
 ## registerField
-the `registerField` function is a utility function for registering form fields and their properties in a
+The `registerField` function is a utility function for registering form fields and their properties in a
 type-safe manner. It takes in two arguments - `fieldName` and `options` - and returns a
 `RegisterFieldResult`.
 

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -99,6 +99,11 @@ const config: DocsThemeConfig = {
   themeSwitch: {
     component: null,
   },
+  useNextSeoProps() {
+    return {
+      titleTemplate: '%s – React Form Ally',
+    };
+  },
 };
 
 export default config;


### PR DESCRIPTION
- also a few minor typos I found during a thorough reading of the docs.

Left is after this change, right is before.

<img width="492" alt="Screenshot 2023-04-10 at 2 15 57 PM" src="https://user-images.githubusercontent.com/5385284/230965672-33bd8338-1325-47df-a45b-8e177219c1ff.png">
